### PR TITLE
Ross

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Sysplotter data and configuration files #
+######################
+sysplotter_config.mat
+sysplotter_data


### PR DESCRIPTION
This change fixes the directory structure (so that sysplotter_config will complete) and so that the appropriate .gitignore is in the main folder.